### PR TITLE
do not close device mananger before async operation of enumerate devices

### DIFF
--- a/FridaTests/FridaTests.swift
+++ b/FridaTests/FridaTests.swift
@@ -20,10 +20,10 @@ class FridaTests: XCTestCase {
             devices = try! result()
             expectation.fulfill()
         }
-        manager.close()
 
         self.waitForExpectations(timeout: 5.0, handler: nil)
         // print("Got devices: \(devices)")
+        manager.close()
         XCTAssert(devices.count > 0)
     }
 


### PR DESCRIPTION
Since `DeviceManager.enumerateDevices` is asynchronous operation, we should not call `DeviceManager.close` before asynchronous task completion.

Although `DeviceManager.close` is asynchronous, it is still too early.