### PR TITLE
Fixed build failures in latest Xcode (#13)

### DIFF
--- a/Frida/RpcFunction.swift
+++ b/Frida/RpcFunction.swift
@@ -10,7 +10,7 @@ public struct RpcFunction {
         self.functionName = functionName
     }
 
-    func dynamicallyCall(withArguments args: [Any]) -> RpcRequest {
+    public func dynamicallyCall(withArguments args: [Any]) -> RpcRequest {
         return script.rpcPost(functionName: functionName,
                               requestId: script.nextRequestId, values: args)
     }

--- a/Frida/Script.swift
+++ b/Frida/Script.swift
@@ -269,7 +269,7 @@ public class Script: NSObject, NSCopying {
             self.script = script
         }
 
-        subscript(dynamicMember functionName: String) -> RpcFunction {
+        public subscript(dynamicMember functionName: String) -> RpcFunction {
             get {
                 return RpcFunction(script: self.script, functionName: functionName)
             }


### PR DESCRIPTION
Makes `RpcFunction.dynamicallyCall` and `Exports.subscript(dynamicMember:)` public in order to fix a build-time error when compiling the `Frida` module.