### PR TITLE
Expose argv on ProcessDetails

### DIFF
--- a/Frida/ProcessDetails.swift
+++ b/Frida/ProcessDetails.swift
@@ -30,6 +30,10 @@ public final class ProcessDetails: CustomStringConvertible, Equatable, Hashable,
         return iconDicts.map(Marshal.iconFromVarDict)
     }()
 
+    public lazy var argv: [String]? = {
+        return parameters["argv"] as? [String]
+    }()
+
     public var description: String {
         return "Frida.ProcessDetails(pid: \(pid), name: \"\(name)\", parameters: \(parameters))"
     }


### PR DESCRIPTION
Surface the new full-scope `argv` process parameter (added in frida-core) as a typed accessor on `ProcessDetails`, returning the target's command-line arguments when the backend provides them.

Depends on the corresponding frida-core change: https://github.com/frida/frida-core/pull/1243